### PR TITLE
[Feat] #25 - ForecastList 데이터를 현재시간부터 표시하도록 수정

### DIFF
--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/App/SceneDelegate.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/App/SceneDelegate.swift
@@ -16,8 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: scene)
         
-        window.rootViewController = UINavigationController(rootViewController: ViewController())
-        //window.rootViewController = UINavigationController(rootViewController: MainViewController())
+//        window.rootViewController = UINavigationController(rootViewController: ViewController())
+        window.rootViewController = UINavigationController(rootViewController: MainViewController())
         window.makeKeyAndVisible()
         
         self.window = window

--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/Common/NetworkManager/NetworkManager.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/Common/NetworkManager/NetworkManager.swift
@@ -108,7 +108,7 @@ class NetworkManager {
             .flatMap { weatherForecast in
                 
                 // 예보에서 아이콘 코드 최대 10개 추출
-                let iconIds = weatherForecast.list.prefix(10).compactMap { $0.weather.first?.icon }
+                let iconIds = weatherForecast.list.prefix(12).compactMap { $0.weather.first?.icon }
                 
                 // 각 아이콘 코드로부터 이미지 데이터 다운로드 요청 Single 배열
                 let imageSingles = iconIds.map { iconIds in

--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/CollectionViewCell/ForecastListCell.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/CollectionViewCell/ForecastListCell.swift
@@ -51,6 +51,12 @@ class ForecastListCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func setFirstCell(data: ForecastList, icon: UIImage) {
+        timeLabel.text = "Now"
+        tempLabel.text = "\(Int(data.main.temp))°C"
+        weatherIcon.image = icon
+    }
+    
     func setCell(data: ForecastList, icon: UIImage) {
         timeLabel.text = self.changeDate(data: data)
         tempLabel.text = "\(Int(data.main.temp))°C"
@@ -60,7 +66,6 @@ class ForecastListCell: UICollectionViewCell {
     private func changeDate(data: ForecastList) -> String {
         let date = data.dtTxt.components(separatedBy: " ")
         guard let hour = Int(String(date[1].prefix(2))) else { return "" }
-//        guard let day = Int(String(date[0].suffix(2))) else { return "" }
         
         if hour > 12 {
             return "\(hour - 12)PM"

--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/Main/MainViewController.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/Main/MainViewController.swift
@@ -143,8 +143,13 @@ extension MainViewController: UICollectionViewDataSource {
             
             guard let data = self.viewModel.output.forecastListCellData.value else { return cell }
             
-            cell.setCell(data: data.forecastList[indexPath.row],
-                         icon: data.weatherIcons[indexPath.row])
+            if indexPath.row == 0 {
+                cell.setFirstCell(data: data.forecastList[indexPath.row],
+                                  icon: data.weatherIcons[indexPath.row])
+            } else {
+                cell.setCell(data: data.forecastList[indexPath.row],
+                             icon: data.weatherIcons[indexPath.row])
+            }
             
             return cell
         case .tenDayForecast:

--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/ViewModel/Main/MainViewModel.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/ViewModel/Main/MainViewModel.swift
@@ -53,26 +53,24 @@ class MainViewModel {
     }
     
     private func loadForecastListData() {
-        NetworkManager.shared.fetchForeCastData(lat: 37.5, lon: 126.9)
-            .flatMap { forecast in
-                let tenItems = [ForecastList](forecast.list.prefix(10))
-                
-                let imageSingle = tenItems.map { list in
-                    NetworkManager.shared.loadIconImage(icon: list.weather[0].icon)
+        NetworkManager.shared.fetchForeCastAndTenImageData(lat: 37.5, lon: 126.9)
+            .subscribe { weather, data in
+                var image = [UIImage]()
+                data.forEach {
+                    guard let changedData = UIImage(data: $0) else { return }
+                    image.append(changedData)
                 }
                 
-                return Single.zip(imageSingle)
-                    .map { image in
-                        ForecastData(forecastList: tenItems, weatherIcons: image)
-                    }
-            }
-            .subscribe { data in
-                self.output.forecastListCellData.accept(data)
+                var list = [ForecastList](weather.list.prefix(12))
+                list.removeFirst(2)
+                image.removeFirst(2)
                 
+                let result = ForecastData(forecastList: list, weatherIcons: image)
+                self.output.forecastListCellData.accept(result)
             } onFailure: { error in
                 print(error)
             }.disposed(by: disposeBag)
-        
+
     }
     
     private func loadWeatherResponseData() {


### PR DESCRIPTION
close #25 

## *⛳️ Work Description*
- NetworkManager의 변경 사항 적용
- ForecastList Cell의 내용을 현재 시간부터 표시하도록 변경
 
## *📸 Screenshot*
![Simulator Screenshot - iPhone 16 - 2025-05-23 at 19 40 31](https://github.com/user-attachments/assets/13cc646e-8cd2-446a-b804-54f791772b07)


## *📢 To Reviewers*
- 코드리뷰 부탁드립니다. 


## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
