### PR TITLE
[Fix] #63 - 컬렉션 뷰 마지막 섹션 구분선 사라지는 버그 수정

### DIFF
--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/CollectionViewCell/TenDayForecastCell.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/CollectionViewCell/TenDayForecastCell.swift
@@ -90,6 +90,8 @@ class TenDayForecastCell: UICollectionViewCell {
         minTempLabel.text = "\(Int(data.tempMin))" + tempResult
         maxTempLabel.text = "\(Int(data.tempMax))" + tempResult
         progressBar.update(currentTemp: currentTemp, minTemp: data.tempMin, maxTemp: data.tempMax)
+        
+        separatorView.isHidden = false
     }
     
     func setToday() {


### PR DESCRIPTION
close #63 

## *⛳️ Work Description*
- 마지막 섹션의 구분선이 가끔 표시되지 않던 버그 수정
 
## *📸 Screenshot*
![Simulator Screenshot - iPhone 16 - 2025-05-27 at 09 47 36](https://github.com/user-attachments/assets/cb0d9175-b066-4cea-832c-85c39aa518ff)


## *📢 To Reviewers*
- 코드리뷰 부탁드립니다. 


## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
