### PR TITLE
[Feat] #66 옷 추천 섭씨 화씨 변환 추가

### DIFF
--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/Main/MainViewController.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/Main/MainViewController.swift
@@ -247,9 +247,10 @@ extension MainViewController: UICollectionViewDataSource {
                 if let weather = viewModel.output.mainCellData.value {
                     let temp = weather.main.temp
                     let condition = weather.weather.first?.main ?? "Clear"
+                    let unit = viewModel.tempUnit.value
 
                     // ViewModel 업데이트
-                    clothesViewModel.update(temp: temp, condition: condition)
+                    clothesViewModel.update(temp: temp, condition: condition, tempUnit: unit)
                 }
 
             // ViewModel에서 추천 옷 정보 가져와 셀에 적용

--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/ViewModel/Clothes/ClothesViewModel.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/ViewModel/Clothes/ClothesViewModel.swift
@@ -17,32 +17,39 @@ final class ClothesViewModel {
     
     
     // 외부에서 호출
-    func update(temp: Double, condition: String) {
-        let normalized = condition.lowercased()
-        let result = recommendClothes(temp: temp, condition: normalized)
-        let text = generateMessage(temp: temp, condition: normalized)
+    func update(temp: Double, condition: String, tempUnit: Int) {
+        let normalizedTemp = tempUnit == 0 ? temp : fahrenheitToCelsius(temp)
+        let normalizedCondition = condition.lowercased()
+        let result = recommendClothes(temp: normalizedTemp, condition: normalizedCondition)
+        let text = generateMessage(displayTemp: temp, tempForLogic: normalizedTemp, condition: normalizedCondition, tempUnit: tempUnit)
         recommendation.accept(result)
         message.accept(text)
     }
     
-    private func generateMessage(temp: Double, condition: String) -> String {
+    private func fahrenheitToCelsius(_ f: Double) -> Double {
+        return (f - 32) * 5 / 9
+    }
+
+    private func generateMessage(displayTemp: Double, tempForLogic: Double, condition: String, tempUnit: Int) -> String {
+        let unitLabel = tempUnit == 0 ? "섭씨" : "화씨"
+        let prefix = "\(unitLabel) \(Int(displayTemp))도입니다! "
             switch condition {
             case "rain":
-                return "\(Int(temp))도입니다! 우산 챙기고 방수 옷을 입으세요 ☔️"
+                return prefix + "우산 챙기고 방수 옷을 입으세요 ☔️"
             case "snow":
-                return "\(Int(temp))도입니다! 눈 오는 날엔 따뜻하게 입으세요 ❄️"
+                return prefix + "눈 오는 날엔 따뜻하게 입으세요 ❄️"
             default:
-                switch temp {
+                switch tempForLogic {
                 case ..<5:
-                    return "\(Int(temp))도입니다! 매우 추우니 패딩은 필수예요 🥶"
+                    return prefix + "매우 추우니 패딩은 필수예요 🥶"
                 case 5..<15:
-                    return "\(Int(temp))도입니다! 쌀쌀하니 겉옷을 챙기세요 🧥"
+                    return prefix + "쌀쌀하니 겉옷을 챙기세요🧥"
                 case 15..<22:
-                    return "\(Int(temp))도입니다! 선선한 날씨예요 👌"
+                    return prefix + "선선한 날씨예요 👌"
                 case 22..<28:
-                    return "\(Int(temp))도입니다! 가볍게 입기 좋아요 ☀️"
+                    return prefix + "가볍게 입기 좋아요 ☀️"
                 default:
-                    return "\(Int(temp))도입니다! 더우니 시원하게 입으세요 🔥"
+                    return prefix + "더우니 시원하게 입으세요 🔥"
                 }
             }
         }


### PR DESCRIPTION
close #번호
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*
- `ClothesViewModel` 내부 `update()` 메서드에서 온도 단위(Celsius/Fahrenheit)에 따른 변환 로직 추가
- 메시지 생성 로직(`generateMessage`)에 단위 표현("섭씨", "화씨") 동적 반영
- 기존 하드코딩된 섭씨 기준 메시지를 제거하고, tempUnit 상태를 기반으로 뷰에 출력되는 온도와 메시지 일치
- 의류 추천 로직은 항상 섭씨>화씨 변환된 수치를 기준으로 유지하여 일관된 판단 가능

 
## *📸 Screenshot*
<p align="center">
<img src="https://github.com/user-attachments/assets/b53a2268-a9ae-412a-8f88-ed23b6383346" width="45%" /> 
<img src="https://github.com/user-attachments/assets/d4b252ed-730b-431f-bc02-3a51ba801697" width="45%" />
</p>


