### PR TITLE
[Fix] 옷 추천 메시지 줄 바뀜 문제 해결

### DIFF
--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/CollectionViewCell/ClothesCell.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/CollectionViewCell/ClothesCell.swift
@@ -16,7 +16,10 @@ class ClothesCell: UICollectionViewCell {
         label.font = .systemFont(ofSize: 15, weight: .medium)
         label.textColor = .white
         label.textAlignment = .center
-        label.numberOfLines = 0
+        label.numberOfLines = 1
+        label.lineBreakMode = .byClipping               // 줄임표 없이 잘라내지 않음
+        label.adjustsFontSizeToFitWidth = true          // 필요 시 글자 크기 줄임
+        label.minimumScaleFactor = 0.7                  // 최소 70%까지 줄이기 허용
         return label
     }()
     


### PR DESCRIPTION
close #번호
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*
- 옷 추천 메시지 라벨에 긴 텍스트가 잘리는 문제 수정
- 줄임표(...) 대신 `byClipping` 모드로 표시되도록 설정 → 글자가 짤리더라도 줄임표 없이 표시
- `adjustsFontSizeToFitWidth = true`로 텍스트가 라벨 너비에 맞게 자동 축소되도록 처리
- `minimumScaleFactor = 0.7` 설정으로 최소 70% 크기까지 글자 축소 가능하게 설정
 
## *📸 Screenshot*
<img width="853" alt="image" src="https://github.com/user-attachments/assets/8a1d6403-4eab-477d-ae44-11c44661048d" />
<p align="center">
<img src="https://github.com/user-attachments/assets/e9d5667a-b48a-4372-bb09-9697861fc184" width="45%" /> 
</p>