### PR TITLE
[Fix] #75 - ForecastList 데이터 시간에 맞춰 수정하는 작업

### DIFF
--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/CollectionViewCell/ForecastListCell.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/View/CollectionViewCell/ForecastListCell.swift
@@ -59,21 +59,17 @@ class ForecastListCell: UICollectionViewCell {
     }
     
     private func changeDate(data: ForecastList) -> String {
-        let date = data.dtTxt.components(separatedBy: " ")
-        guard var hour = Int(String(date[1].prefix(2))) else { return "" }
-        hour += 9
+        // dt에 저장된 Unix timestamp를 Date타입으로 변환
+        let customDate = Date(timeIntervalSince1970: Double(data.dt))
         
-        if hour >= 24 {
-            hour -= 24
-        }
+        // DateFormatter 생성
+        let customDateFormatter = DateFormatter()
+        // DateFormatter의 포맷을 "시간+AM or PM"으로 설정
+        customDateFormatter.dateFormat = "ha"
+        // DateFormat 실행
+        let hour = customDateFormatter.string(from: customDate)
         
-        if hour > 12 {
-            return "\(hour - 12)PM"
-        } else if hour == 12 {
-            return "\(hour)PM"
-        } else {
-            return "\(hour)AM"
-        }
+        return hour
     }
     
     private func setupUI() {

--- a/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/ViewModel/Main/MainViewModel.swift
+++ b/Spr-summmer-fal-winnnter/Spr-summmer-fal-winnnter/ViewModel/Main/MainViewModel.swift
@@ -114,6 +114,24 @@ class MainViewModel {
             }).disposed(by: disposeBag)
     }
     
+    // yyyy-MM-dd HH:mm:ss가 기본, a는 AM/PM
+    // hh(소문자)는 12시간 단위, h는 한 자리만 표시
+    // ForecastList.dt의 Unix Timestamp 값을 format으로 넣어준 형태의 String으로 변환하는 메서드
+    private func unixTimeStampToString(unixTimeStamp: Int, format: String) -> String {
+        
+        // dt에 저장된 Unix timestamp를 Date타입으로 변환
+        let customDate = Date(timeIntervalSince1970: Double(unixTimeStamp))
+        
+        // DateFormatter 생성
+        let customDateFormatter = DateFormatter()
+        // DateFormatter의 포맷을 "시간+AM or PM"으로 설정
+        customDateFormatter.dateFormat = format
+        // DateFormat 실행
+        let hour = customDateFormatter.string(from: customDate)
+        
+        return hour
+    }
+    
     // ForecastList의 데이터를 CustomForecastList로 변환하는 메서드
     private func transformForecastListData(data: [ForecastList]) {
         var list = data                 // removeFirst 메서드를 사용하기 위해 변수 생성
@@ -121,33 +139,32 @@ class MainViewModel {
         var result = [[ForecastList]]() // 데이터를 하루 단위의 배열로 가지게 될 변수
         
         // 첫 데이터의 시간 체크
-        guard var firstHour = Int(list[0].dtTxt.components(separatedBy: " ")[1].prefix(2)) else { return }
-        firstHour += 9
+        let firstHour = self.unixTimeStampToString(unixTimeStamp: list[0].dt, format: "ha")
         
         // 첫 날(오늘) 데이터를 box에 담음
         switch firstHour {
-        case 09:
+        case "12AM":
             box.append(list.removeFirst())
             fallthrough
-        case 12:
+        case "3AM":
             box.append(list.removeFirst())
             fallthrough
-        case 15:
+        case "6AM":
             box.append(list.removeFirst())
             fallthrough
-        case 18:
+        case "9AM":
             box.append(list.removeFirst())
             fallthrough
-        case 21:
+        case "12PM":
             box.append(list.removeFirst())
             fallthrough
-        case 24:
+        case "3PM":
             box.append(list.removeFirst())
             fallthrough
-        case 27:
+        case "6PM":
             box.append(list.removeFirst())
             fallthrough
-        case 30:
+        case "9PM":
             box.append(list.removeFirst())
             fallthrough
         default:
@@ -178,9 +195,9 @@ class MainViewModel {
         
         // result -> customForecastList 변환 작업
         result.forEach {
-            let day = String($0.last?.dtTxt.split(separator: " ")[0].suffix(2) ?? "")
+            let day = self.unixTimeStampToString(unixTimeStamp: $0[0].dt, format: "d")
             let tempMin = $0.sorted(by: { $0.main.tempMin < $1.main.tempMin })[0].main.tempMin
-            let tempMax = $0.sorted(by: { $0.main.tempMax > $1.main.tempMax })[0].main.tempMin
+            let tempMax = $0.sorted(by: { $0.main.tempMax > $1.main.tempMax })[0].main.tempMax
             let pop = $0.sorted(by: { $0.pop > $1.pop })[0].pop
             let icon = $0.sorted(by: { $0.pop > $1.pop })[0].weather[0].icon
             


### PR DESCRIPTION
close #75 

## *⛳️ Work Description*
- 데이터의 시간을 한국 기준 시간으로 변경해 오류를 수정했습니다.
- 10일 이전의 날짜가 0n일 -> n일로 표시되도록 변경했습니다.
 
## *📸 Screenshot*
![Simulator Screenshot - iPhone 16 - 2025-05-28 at 14 38 55](https://github.com/user-attachments/assets/fad2dc95-4edf-4266-a1a6-00532af4a40c)


## *📢 To Reviewers*
- 코드리뷰 부탁드립니다. 


## *✅ Checklist*
- [ ] 주석 및 프린트문 제거 확인.
- [ ] 컨벤션 준수 확인.
